### PR TITLE
PrestoC++ override default sharedArbitratorReservedMemoryGb

### DIFF
--- a/docker-compose-native/prestissimo/workers/config_1.properties
+++ b/docker-compose-native/prestissimo/workers/config_1.properties
@@ -8,3 +8,4 @@ query.max-memory-per-node=3GB
 memory-arbitrator-kind=SHARED
 task.max-drivers-per-task=16
 memory-pool-reserved-capacity=200000000
+shared-arbitrator.reserved-capacity=500MB

--- a/docker-compose-native/prestissimo/workers/config_2.properties
+++ b/docker-compose-native/prestissimo/workers/config_2.properties
@@ -8,3 +8,4 @@ query.max-memory-per-node=3GB
 memory-arbitrator-kind=SHARED
 task.max-drivers-per-task=16
 memory-pool-reserved-capacity=200000000
+shared-arbitrator.reserved-capacity=500MB

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,11 @@ Up above you'll see directories for different topics, and inside each directory 
 <br>
 &nbsp;&nbsp;&nbsp;&nbsp;↳ ```AWS```
 
+## Requirements
+Mac OS X or Linux, with minimum 10G memory and 50G free disk space
+Docker Desktop 4.10.1 (Engine: 24.0.2, Compose: v2.18.1) and above
+At least 10G free memory is required on your machine.
+
 ## Suggestions and Feedback
 
 We would love to hear from you, please **[create an issue](https://github.com/prestodb/prestorials/issues/new/choose)** for:


### PR DESCRIPTION
The default shared-arbitrator.reserved-capacity value of 4GB is too big compared to the config for the query-memory-gb which is set to 3GB.